### PR TITLE
blueprints: Invoke "npm install" only when needed

### DIFF
--- a/blueprints/eslint-config-simplabs/index.js
+++ b/blueprints/eslint-config-simplabs/index.js
@@ -48,15 +48,21 @@ module.exports = {
 
       return writeJson(pkgPath, pkg, { spaces: 2 });
     }).then(() => {
-      let packages = [{ name: 'eslint-plugin-ember' }];
+      let packages = [];
 
-      if (this._hasEmberCLIQUnit()) {
+      if (!this._hasEmberPlugin()) {
+        packages.push({ name: 'eslint-plugin-ember' });
+      }
+
+      if (this._hasEmberCLIQUnit() && !this._hasQUnitPlugin()) {
         packages.push({ name: 'eslint-plugin-qunit' });
-      } else if (this._hasEmberCLIMocha()) {
+      } else if (this._hasEmberCLIMocha() && !this._hasMochaPlugin()) {
         packages.push({ name: 'eslint-plugin-mocha' });
       }
 
-      return this.addPackagesToProject(packages);
+      if (packages.length !== 0) {
+        return this.addPackagesToProject(packages);
+      }
     }).then(() => {
       return this.ui.prompt({
         type: 'confirm',
@@ -74,11 +80,23 @@ module.exports = {
     });
   },
 
+  _hasEmberPlugin() {
+    return 'eslint-plugin-ember' in this.project.dependencies();
+  },
+
   _hasEmberCLIQUnit() {
     return 'ember-cli-qunit' in this.project.dependencies();
   },
 
+  _hasQUnitPlugin() {
+    return 'eslint-plugin-qunit' in this.project.dependencies();
+  },
+
   _hasEmberCLIMocha() {
     return 'ember-cli-mocha' in this.project.dependencies();
+  },
+
+  _hasMochaPlugin() {
+    return 'eslint-plugin-mocha' in this.project.dependencies();
   },
 };

--- a/node-tests/blueprints/eslint-config-simplabs-test.js
+++ b/node-tests/blueprints/eslint-config-simplabs-test.js
@@ -91,6 +91,16 @@ describe('eslint-config-simplabs blueprint', function() {
       });
   });
 
+  it('does not install `eslint-plugin-ember` if it is not needed', function() {
+    return emberNew()
+      .then(() => modifyPackages([
+        { name: 'eslint-plugin-ember', dev: true },
+        { name: 'ember-cli-qunit', delete: true },
+      ]))
+      .then(() => emberGenerate(['eslint-config-simplabs']))
+      .then(() => td.verify(npmTaskRun(td.matchers.anything()), { times: 0 }));
+  });
+
   it('installs `eslint-plugin-qunit` addon', function() {
     return emberNew()
       .then(() => emberGenerate(['eslint-config-simplabs']))


### PR DESCRIPTION
This will make `ember generate eslint-config-simplabs` faster if the dependencies are already installed