### PR TITLE
Disable "ember/local-modules" rule

### DIFF
--- a/plugins/ember.js
+++ b/plugins/ember.js
@@ -4,7 +4,7 @@ module.exports = {
   ],
   rules: {
     // General
-    'ember/local-modules': 'error',
+    'ember/local-modules': 'off',
     'ember/no-observers': 'off',
     'ember/no-side-effects': 'error',
     'ember/jquery-ember-run': 'off',


### PR DESCRIPTION
"New Module Imports" should be used instead. Enabling this rule has made the situation for the codemod far worse than if everyone had just used the global directly...