### PR TITLE
chore(deps): update execa dep (>=0.7.0 - < 1.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "ember-cli-version-checker": "^1.2.0",
-    "execa": "^0.7.0",
+    "execa": ">=0.7.0 <1",
     "fs-extra": "^3.0.1 || ^4.0.0",
     "supports-color": "^4.1.0"
   },


### PR DESCRIPTION
Update dependency for `execa` for the version ranges 0.7.0 - < 1.0.0 

In favor of #47 